### PR TITLE
Add python3 and PyPy support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: Test on push
+
+on:
+  push:
+    branches: ['*']
+  pull_request:
+    branches: ['*']
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['2.7', '3.7', pypy-2.7, pypy-3.7]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Update submodules
+      run: |
+        git submodule sync
+        git submodule update --init --recursive
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        pip install msgpack==1.0.2
+        sudo apt-get install build-essential
+    - name: Build
+      run: |
+        make install PYTHON=python
+    - name: Check import
+      run: |
+        python tests/test_readsnap.py
+    - name: Test with unittest
+      run: |
+        make test PYTHON=python

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ bdist:
 	$(PYTHON) setup.py bdist
 
 bdist_rpm:
-	$(PYTHON) setup.py bdist_rpm
+	$(PYTHON) setup.py bdist_rpm --python=$(PYTHON)
 
 test:
 	$(PYTHON) setup.py test

--- a/README.md
+++ b/README.md
@@ -6,20 +6,33 @@
 
 [Tarantool](https://github.com/tarantool/tarantool) 1.6+ snapshot reader.
 
+## Build and installation
+
+```sh
+git clone https://github.com/viciious/python-tarantool16_snaphot.git
+cd python-tarantool16_snaphot
+git submodule sync
+git submodule update --init --recursive
+make install PYTHON=python3
+# or
+make bdist_rpm PYTHON=python3
+rpm -ivh dist/python3-tarantool17-snapshot-1.4-1.x86_64.rpm
+```
+
 ## Usage
 
 ```python
 
 import tarantool17_snapshot as tarantool_snapshot
-import msgpack
+import msgpack # >= 1.0.2
 
 count = 0
 header = {} # the header dict is optional
 
-try: 
+try:
   for packed_meta, packed_row in tarantool_snapshot.iter("/snaps/00000000010388786179.snap", header = header):
-    meta = msgpack.unpackb(packed_meta)
-    row = msgpack.unpackb(packed_row)
+    meta = msgpack.unpackb(packed_meta, strict_map_key=False, use_list=False)
+    row = msgpack.unpackb(packed_row, strict_map_key=False, use_list=False)
     count += 1
 
     instance = header['Instance'] if 'Instance' in header else header['Server']
@@ -31,11 +44,11 @@ try:
       print("lsn is %s" % meta[3])
     if 4 in meta:
       print("timestamp is %s" % meta[4])
-    
+
     if 16 in row:
       print("space id is %s" % row[16])
     if 33 in row:
-      print("tuple is %s" % row[33])
+      print("tuple is {0}".format(row[33]))
 
   print count
 except Exception as e:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 import sys
 import glob
 import platform
-from setuptools.command.bdist_rpm import bdist_rpm
+from distutils.command.bdist_rpm  import bdist_rpm
 
 RPM_REQUIRED_DEPS = "python-msgpack"
 
@@ -16,19 +16,10 @@ bdist_rpm._original_make_spec_file = bdist_rpm._make_spec_file
 bdist_rpm._make_spec_file = custom_make_spec_file
 ## END OF HACK
 
-try:
-    from setuptools import setup, Extension
-    extra_params = dict(test_suite = 'tests',)
-except ImportError:
-    from distutils.core import setup, Extension
-    extra_params = {}
+if len(sys.argv) > 1 and sys.argv[1] == 'test':
+    import setuptools
 
-def sh(command):
-    import subprocess
-    ret = subprocess.call(command,shell=True)
-    if ret != 0:
-        raise ValueError("command failed: %s" % command)
-    return ret
+from distutils.core import setup, Extension
 
 sources = ["tarantool_snapshot.c"]
 include_dirs = []
@@ -64,12 +55,12 @@ else:
 if sys.version_info.major == 3:
     interpreter += "3"
 
-setup (name = '%s-tarantool17-snapshot' % interpreter,
+setup(name = '%s-tarantool17-snapshot' % interpreter,
     description = 'Tarantool 1.6+ snapshot reader',
     version='1.4',
     author='Victor Luchits',
     author_email='vluchits@gmail.com',
     url='https://github.com/viciious/python-tarantool16_snaphot',
     packages=[],
-    ext_modules = [module1], **extra_params)
+    ext_modules = [module1])
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import glob
+import platform
 from setuptools.command.bdist_rpm import bdist_rpm
 
 RPM_REQUIRED_DEPS = "python-msgpack"
@@ -55,7 +56,15 @@ module1 = Extension('tarantool17_snapshot',
                     extra_link_args = extra_link_args,
                     extra_compile_args = extra_compile_args)
 
-setup (name = 'python-tarantool17-snapshot',
+if platform.python_implementation() == "PyPy":
+    interpreter = "pypy"
+else:
+    interpreter = "python"
+
+if sys.version_info.major == 3:
+    interpreter += "3"
+
+setup (name = '%s-tarantool17-snapshot' % interpreter,
     description = 'Tarantool 1.6+ snapshot reader',
     version='1.4',
     author='Victor Luchits',

--- a/setup.py
+++ b/setup.py
@@ -2,19 +2,6 @@ import os
 import sys
 import glob
 import platform
-from distutils.command.bdist_rpm  import bdist_rpm
-
-RPM_REQUIRED_DEPS = "python-msgpack"
-
-## HACK FOR DEPS IN RPMS
-def custom_make_spec_file(self):
-    spec = self._original_make_spec_file()
-    lineDescription = "%description"
-    spec.insert(spec.index(lineDescription) - 1, "Requires: %s" % RPM_REQUIRED_DEPS)
-    return spec
-bdist_rpm._original_make_spec_file = bdist_rpm._make_spec_file
-bdist_rpm._make_spec_file = custom_make_spec_file
-## END OF HACK
 
 if len(sys.argv) > 1 and sys.argv[1] == 'test':
     import setuptools

--- a/tarantool_snapshot.c
+++ b/tarantool_snapshot.c
@@ -614,17 +614,6 @@ PyMODINIT_FUNC PyInit_tarantool17_snapshot(void) {
     return m;
 }
 
-int main(int argc, char **argv) {
-    wchar_t *program = Py_DecodeLocale(argv[0], NULL);
-    if (program == NULL) {
-        fprintf(stderr, "Fatal error: cannot decode argv[0]\n");
-        exit(1);
-    }
-    Py_SetProgramName(program);
-    Py_Initialize();
-    return 0;
-}
-
 #else
 
 // backward compatibility
@@ -647,13 +636,6 @@ PyMODINIT_FUNC inittarantool17_snapshot(void) {
     SnapshotError = PyErr_NewException((char *)"tarantool17_snapshot.SnapshotError", (PyObject *)NULL, (PyObject *)NULL);
     Py_INCREF(SnapshotError);
     PyModule_AddObject(m, "SnapshotError", SnapshotError);
-}
-
-int main(int argc, char **argv) {
-    Py_SetProgramName(argv[0]);
-    Py_Initialize();
-    inittarantool17_snapshot();
-    return 0;
 }
 
 #endif

--- a/tarantool_snapshot.c
+++ b/tarantool_snapshot.c
@@ -43,6 +43,10 @@
 
 #define FADVD_WINDOW_SIZE ( 10 * 1024 * 1024 )
 
+#if PY_MAJOR_VERSION >= 3
+#define Py_TPFLAGS_HAVE_ITER 0
+#endif
+
 /*
  * marker is MsgPack fixext2
  * +--------+--------+--------+--------+
@@ -101,8 +105,7 @@ PyObject* SnapshotIterator_iter(SnapshotIterator *self);
 PyObject* SnapshotIterator_iternext(SnapshotIterator *self);
 
 static PyTypeObject SnapshotIterator_Type = {
-    PyObject_HEAD_INIT(NULL)
-    0,                         /*ob_size*/
+    PyVarObject_HEAD_INIT(NULL, 0)
     "tarantool17_snapshot.SnapshotIterator",      /*tp_name*/
     sizeof(SnapshotIterator),      /*tp_basicsize*/
     0,                         /*tp_itemsize*/
@@ -259,7 +262,7 @@ static int SnapshotIterator_init(SnapshotIterator *self, PyObject *args, PyObjec
         if (header_dict == NULL)
             continue;
 
-        PyObject *pyval = PyString_FromString(val);
+        PyObject *pyval = PyUnicode_FromString(val);
         PyDict_SetItemString(header_dict, key, pyval);
         Py_DECREF(pyval);
     }
@@ -313,7 +316,12 @@ error:
 
     const char *row_end = *pos;
 
+#if PY_MAJOR_VERSION >= 3
+    *dest = Py_BuildValue("(y#,y#)", meta_pos,  meta_end - meta_pos, row_pos, row_end - row_pos);
+#else
+    // backward compatibility
     *dest = Py_BuildValue("(s#,s#)", meta_pos,  meta_end - meta_pos, row_pos, row_end - row_pos);
+#endif
 
     return 0;
 }
@@ -497,7 +505,7 @@ decompress_row:
                 snprintf(self->error_buf, sizeof(self->error_buf), "out of memory");
                 return -1;
             }
-            zstd->outbuf.dst = newdst; 
+            zstd->outbuf.dst = newdst;
         } while (1);
     }
 
@@ -574,6 +582,53 @@ static PyMethodDef TarantoolSnapshot_Module_Methods[] = {
     {NULL}  /* Sentinel */
 };
 
+#if PY_MAJOR_VERSION >= 3
+
+PyMODINIT_FUNC PyInit_tarantool17_snapshot(void) {
+    PyObject *m;
+
+    SnapshotIterator_Type.tp_new = PyType_GenericNew;
+    if (PyType_Ready(&SnapshotIterator_Type) < 0)  return NULL;
+
+    static struct PyModuleDef moduledef = {
+        PyModuleDef_HEAD_INIT,
+        "tarantool17_snapshot",
+        "tarantool 1.7 snapshot",
+        -1,
+        TarantoolSnapshot_Module_Methods,
+    };
+
+    m = PyModule_Create(&moduledef);
+
+    if (!m) {
+        return NULL;
+    }
+
+    Py_INCREF(&SnapshotIterator_Type);
+    PyModule_AddObject(m, "iter", (PyObject *)&SnapshotIterator_Type);
+
+    SnapshotError = PyErr_NewException((char *)"tarantool17_snapshot.SnapshotError", (PyObject *)NULL, (PyObject *)NULL);
+    Py_INCREF(SnapshotError);
+    PyModule_AddObject(m, "SnapshotError", SnapshotError);
+
+    return m;
+}
+
+int main(int argc, char **argv) {
+    wchar_t *program = Py_DecodeLocale(argv[0], NULL);
+    if (program == NULL) {
+        fprintf(stderr, "Fatal error: cannot decode argv[0]\n");
+        exit(1);
+    }
+    Py_SetProgramName(program);
+    Py_Initialize();
+    return 0;
+}
+
+#else
+
+// backward compatibility
+
 PyMODINIT_FUNC inittarantool17_snapshot(void) {
     PyObject *m;
 
@@ -581,6 +636,7 @@ PyMODINIT_FUNC inittarantool17_snapshot(void) {
     if (PyType_Ready(&SnapshotIterator_Type) < 0)  return;
 
     m = Py_InitModule("tarantool17_snapshot", TarantoolSnapshot_Module_Methods);
+
     if (!m) {
         return;
     }
@@ -590,7 +646,7 @@ PyMODINIT_FUNC inittarantool17_snapshot(void) {
 
     SnapshotError = PyErr_NewException((char *)"tarantool17_snapshot.SnapshotError", (PyObject *)NULL, (PyObject *)NULL);
     Py_INCREF(SnapshotError);
-    PyModule_AddObject(m, "SnapshotError", SnapshotError); 
+    PyModule_AddObject(m, "SnapshotError", SnapshotError);
 }
 
 int main(int argc, char **argv) {
@@ -599,3 +655,5 @@ int main(int argc, char **argv) {
     inittarantool17_snapshot();
     return 0;
 }
+
+#endif

--- a/tests/test_readsnap.py
+++ b/tests/test_readsnap.py
@@ -1,7 +1,7 @@
 import tarantool17_snapshot
 import msgpack
 from unittest import TestCase
-import fixtures
+import tests.fixtures as fixtures
 
 class TestSnapshot(TestCase):
     def test_read_v12(self):
@@ -10,16 +10,16 @@ class TestSnapshot(TestCase):
 
         try:
             for meta_data, row_data in tarantool17_snapshot.iter("testdata/v12/00000000000000000000.ok.snap"):
-                meta = msgpack.unpackb(meta_data)
-                row = msgpack.unpackb(row_data)
+                meta = msgpack.unpackb(meta_data, strict_map_key=False, raw=False)
+                row = msgpack.unpackb(row_data, strict_map_key=False, raw=False)
 
                 metas.append(meta)
                 rows.append(row)
         except:
             self.fail("Reading v12 snapshot failed")
 
-        self.assertEquals(fixtures.v12_metas, metas)
-        self.assertEquals(fixtures.v12_rows, rows)
+        self.assertEqual(fixtures.v12_metas, metas)
+        self.assertEqual(fixtures.v12_rows, rows)
 
     def test_read_v12_header(self):
         header = {}
@@ -29,7 +29,7 @@ class TestSnapshot(TestCase):
         except:
             self.fail("Reading v12 snapshot header failed")
 
-        self.assertEquals(fixtures.v12_header, header)
+        self.assertEqual(fixtures.v12_header, header)
 
     def test_read_v13(self):
         metas = []
@@ -37,16 +37,16 @@ class TestSnapshot(TestCase):
 
         try:
             for meta_data, row_data in tarantool17_snapshot.iter("testdata/v13/00000000000000000000.ok.snap"):
-                meta = msgpack.unpackb(meta_data)
-                row = msgpack.unpackb(row_data)
+                meta = msgpack.unpackb(meta_data, strict_map_key=False, raw=False)
+                row = msgpack.unpackb(row_data, strict_map_key=False, raw=False)
 
                 metas.append(meta)
                 rows.append(row)
         except:
             self.fail("Reading v13 snapshot failed")
 
-        self.assertEquals(fixtures.v13_metas, metas)
-        self.assertEquals(fixtures.v13_rows, rows)
+        self.assertEqual(fixtures.v13_metas, metas)
+        self.assertEqual(fixtures.v13_rows, rows)
 
     def test_read_v13_header(self):
         header = {}
@@ -56,42 +56,42 @@ class TestSnapshot(TestCase):
         except:
             self.fail("Reading v13 snapshot header failed")
 
-        self.assertEquals(fixtures.v13_header, header)
+        self.assertEqual(fixtures.v13_header, header)
 
     def test_bigsnap_v13(self):
         count = 0
         try:
             for meta_data, row_data in tarantool17_snapshot.iter("testdata/v13/00000000000000010005.ok.snap"):
-                msgpack.unpackb(meta_data)
-                msgpack.unpackb(row_data)
+                msgpack.unpackb(meta_data, strict_map_key=False, raw=False)
+                msgpack.unpackb(row_data, strict_map_key=False, raw=False)
 
                 count = count + 1
         except:
             self.fail("Reading v13 snapshot failed")
 
-        self.assertEquals(count, 10511)
+        self.assertEqual(count, 10511)
 
     def test_corrupted_zstd_v13(self):
         with self.assertRaises(tarantool17_snapshot.SnapshotError) as ctx:
             for _, _ in tarantool17_snapshot.iter("testdata/v13/corr.block.snap"):
                 pass
-        self.assertEquals(str(ctx.exception), "Error reading 'testdata/v13/corr.block.snap': zstd error: Corrupted block detected")
+        self.assertEqual(str(ctx.exception), "Error reading 'testdata/v13/corr.block.snap': zstd error: Corrupted block detected")
 
     def test_no_eof_v13(self):
         with self.assertRaises(tarantool17_snapshot.SnapshotError) as ctx:
             for _, _ in tarantool17_snapshot.iter("testdata/v13/no.eof.snap"):
                 pass
-        self.assertEquals(str(ctx.exception), "Error reading 'testdata/v13/no.eof.snap': truncated stream")
+        self.assertEqual(str(ctx.exception), "Error reading 'testdata/v13/no.eof.snap': truncated stream")
 
     def test_bad_version_xlog(self):
         with self.assertRaises(tarantool17_snapshot.SnapshotError) as ctx:
             for _, _ in tarantool17_snapshot.iter("testdata/version.bad.xlog"):
                 pass
-        self.assertEquals(str(ctx.exception), "Error opening 'testdata/version.bad.xlog': unknown header version: 0.07\n")
+        self.assertEqual(str(ctx.exception), "Error opening 'testdata/version.bad.xlog': unknown header version: 0.07\n")
 
     def test_bad_format(self):
         with self.assertRaises(tarantool17_snapshot.SnapshotError) as ctx:
             for _, _ in tarantool17_snapshot.iter("testdata/format.bad.xlog"):
                 pass
-        self.assertEquals(str(ctx.exception), "Error opening 'testdata/format.bad.xlog': unknown file header: expected SNAP or XLOG")
+        self.assertEqual(str(ctx.exception), "Error opening 'testdata/format.bad.xlog': unknown file header: expected SNAP or XLOG")
 

--- a/tests/test_readsnap.py
+++ b/tests/test_readsnap.py
@@ -1,7 +1,10 @@
 import tarantool17_snapshot
 import msgpack
 from unittest import TestCase
-import tests.fixtures as fixtures
+try:
+    import fixtures
+except:
+    import tests.fixtures as fixtures
 
 class TestSnapshot(TestCase):
     def test_read_v12(self):


### PR DESCRIPTION
Поддержка 3 питона и pypy с сохранением обратной совместимости.
Релевантные изменениям ссылки:
1. http://python3porting.com/cextensions.html
2. https://docs.python.org/3/c-api/arg.html#c.Py_BuildValue

Зависимость `rpm` от `python-msgpack` убрана, так как пакет в некоторых средах либо сильно старый, либо его вообще нет.
Лучше ставить конкретную версию так: `pip install msgpack==1.0.2`

Изменения в тестах:
1. assertEquals заменен на `assertEqual`, т.к. первый устарел
2. помимо относительного импорта fixtures добавлен абсолютный, так как на разных версиях питона по разному работает
3. добавлен параметр `strict_map_key=False` в связи с изменениями в API msgpack: https://github.com/msgpack/msgpack-python/blob/master/README.md#major-breaking-changes-in-msgpack-10
4. добавлен параметр `raw=False` просто чтобы явно показать что в тестах проверяются строки.

---

Для сборки под 3 питон `make PYTHON=python3.6`

Для сборки под pypy скачать и распаковать: https://www.pypy.org/download.html
Поставить нужные пакеты:
```sh
/root/pypy3.7-v7.3.3-linux64/bin/pypy -m ensurepip
/root/pypy3.7-v7.3.3-linux64/bin/pypy -m pip install --upgrade setuptools msgpack
```
Далее что-то типа `make PYTHON=/root/pypy3.7-v7.3.3-linux64/bin/pypy`

---

Для разных интерпретаторов будут разные имена пакетов:
```
make bdist_rpm PYTHON=/root/pypy3.7-v7.3.3-linux64/bin/pypy
# pypy3-tarantool17-snapshot-1.4-1.x86_64.rpm

make bdist_rpm PYTHON=python3.6
# python3-tarantool17-snapshot-1.4-1.x86_64.rpm
```
Для версий < 3 будет pypy-... и python-...

---

Про скорость pypy:
> CPython C extension modules: Any C extension module recompiled with PyPy takes a very large hit in performance. PyPy supports C extension modules solely to provide basic functionality. If the extension module is for speedup purposes only, then it makes no sense to use it with PyPy at the moment. Instead, remove it and use a native Python implementation, which also allows opportunities for JIT optimization. If the extension module is both performance-critical and an interface to some C library, then it might be worthwhile to consider rewriting it as a pure Python version that uses CFFI for the interface.
https://www.pypy.org/performance.html

---

Про rpm:
1. Для python папка установки либы будет как обычно `\usr\lib64\pythonX.X\site-packages\`
2. Для pypy папка установки либы будет `<корень pypy>\site-packages\`

Общая логика, как я понял, заключается в том, что путь берется из `sysconfig.get_paths()`